### PR TITLE
SDE-5196 Save queries when checking m2m fields

### DIFF
--- a/src/dirtyfields/dirtyfields.py
+++ b/src/dirtyfields/dirtyfields.py
@@ -144,6 +144,11 @@ class DirtyFieldsMixin(object):
 
         return self._original_state[field_name]
 
+    def start_dirty_tracking(self):
+        self.ENABLE_M2M_CHECK = True
+        self._connect_m2m_relations()
+        reset_state(sender=self.__class__, instance=self)
+
 
 def reset_state(sender, instance, **kwargs):
     # original state should hold all possible dirty fields to avoid
@@ -167,7 +172,4 @@ def reset_state(sender, instance, **kwargs):
         instance._original_state = new_state
 
     if instance.ENABLE_M2M_CHECK:
-        if not hasattr(instance, '_original_m2m_state') and kwargs.get('action') == 'pre_add':
-            instance._original_m2m_state = instance._as_dict_m2m()
-        if kwargs.get('action') == 'post_add':
-            instance._original_m2m_state = instance._as_dict_m2m()
+        instance._original_m2m_state = instance._as_dict_m2m()

--- a/src/dirtyfields/dirtyfields.py
+++ b/src/dirtyfields/dirtyfields.py
@@ -172,7 +172,7 @@ def reset_state(sender, instance, **kwargs):
         instance._original_state = new_state
     if instance.ENABLE_M2M_CHECK:
         instance._original_m2m_state = instance._as_dict_m2m()
-    if instance.RESET_STATE_ON_SAVE_ONLY:
+    elif instance.RESET_STATE_ON_SAVE_ONLY:
         instance._m2m_dirty = False
 
 

--- a/src/dirtyfields/dirtyfields.py
+++ b/src/dirtyfields/dirtyfields.py
@@ -16,6 +16,9 @@ class DirtyFieldsMixin(object):
     # This mode has been introduced to handle some situations like this one:
     # https://github.com/romgar/django-dirtyfields/issues/73
     ENABLE_M2M_CHECK = False
+
+    # Flag to stop resetting the state on every M2M change, only reset after
+    # post_save(), saving us DB queries
     DISABLE_RESET_STATE_ON_M2M_CHANGED = False
 
     FIELDS_TO_CHECK = None

--- a/src/dirtyfields/dirtyfields.py
+++ b/src/dirtyfields/dirtyfields.py
@@ -16,6 +16,7 @@ class DirtyFieldsMixin(object):
     # This mode has been introduced to handle some situations like this one:
     # https://github.com/romgar/django-dirtyfields/issues/73
     ENABLE_M2M_CHECK = False
+    DISABLE_RESET_STATE_ON_M2M_CHANGED = False
 
     FIELDS_TO_CHECK = None
 
@@ -30,9 +31,10 @@ class DirtyFieldsMixin(object):
         reset_state(sender=self.__class__, instance=self)
 
     def _connect_m2m_relations(self):
+        m2m_handler = set_m2m_dirty if self.DISABLE_RESET_STATE_ON_M2M_CHANGED else reset_state
         for m2m_field, model in get_m2m_with_model(self.__class__):
             m2m_changed.connect(
-                reset_state, sender=remote_field(m2m_field).through, weak=False,
+                m2m_handler, sender=remote_field(m2m_field).through, weak=False,
                 dispatch_uid='{name}-DirtyFieldsMixin-sweeper-m2m'.format(
                     name=self.__class__.__name__))
 
@@ -109,8 +111,6 @@ class DirtyFieldsMixin(object):
                                          self.compare_function)
 
         if check_m2m:
-            if not hasattr(self, '_original_m2m_state'):
-                self._original_m2m_state = self._as_dict_m2m()
             modified_m2m_fields = compare_states(check_m2m,
                                                  self._original_m2m_state,
                                                  self.compare_function)
@@ -123,6 +123,8 @@ class DirtyFieldsMixin(object):
         return modified_fields
 
     def is_dirty(self, check_relationship=False, check_m2m=None):
+        if self.DISABLE_RESET_STATE_ON_M2M_CHANGED and self._m2m_dirty:
+            return True
         return {} != self.get_dirty_fields(check_relationship=check_relationship,
                                            check_m2m=check_m2m)
 
@@ -144,16 +146,10 @@ class DirtyFieldsMixin(object):
 
         return self._original_state[field_name]
 
-    def start_dirty_tracking(self):
-        self.ENABLE_M2M_CHECK = True
-        self._connect_m2m_relations()
-        reset_state(sender=self.__class__, instance=self)
-
 
 def reset_state(sender, instance, **kwargs):
     # original state should hold all possible dirty fields to avoid
     # getting a `KeyError` when checking if a field is dirty or not
-
     update_fields = kwargs.pop('update_fields', {})
     new_state = instance._as_dict(check_relationship=True)
     FIELDS_TO_CHECK = getattr(instance, "FIELDS_TO_CHECK", None)
@@ -170,6 +166,11 @@ def reset_state(sender, instance, **kwargs):
 
     else:
         instance._original_state = new_state
-
     if instance.ENABLE_M2M_CHECK:
         instance._original_m2m_state = instance._as_dict_m2m()
+    if instance.DISABLE_RESET_STATE_ON_M2M_CHANGED:
+        instance._m2m_dirty = False
+
+
+def set_m2m_dirty(sender, instance, **kwargs):
+    instance._m2m_dirty = True

--- a/src/dirtyfields/dirtyfields.py
+++ b/src/dirtyfields/dirtyfields.py
@@ -17,8 +17,9 @@ class DirtyFieldsMixin(object):
     # https://github.com/romgar/django-dirtyfields/issues/73
     ENABLE_M2M_CHECK = False
 
-    # Flag to stop resetting the state on every M2M change, only reset after
-    # post_save(), saving us DB queries
+    # Flag to track M2M changes as a simple boolean; less accurate than
+    # ENABLE_M2M_CHECK as we're only tracking if m2m relations were updated,
+    # not whether they are dirty
     ENABLE_BASIC_M2M_CHECK = False
 
     FIELDS_TO_CHECK = None

--- a/src/dirtyfields/dirtyfields.py
+++ b/src/dirtyfields/dirtyfields.py
@@ -19,7 +19,7 @@ class DirtyFieldsMixin(object):
 
     # Flag to stop resetting the state on every M2M change, only reset after
     # post_save(), saving us DB queries
-    RESET_STATE_ON_SAVE_ONLY = False
+    ENABLE_BASIC_M2M_CHECK = False
 
     FIELDS_TO_CHECK = None
 
@@ -31,11 +31,10 @@ class DirtyFieldsMixin(object):
                 name=self.__class__.__name__))
         if self.ENABLE_M2M_CHECK:
             self._connect_m2m_relations()
-        if not self.RESET_STATE_ON_SAVE_ONLY:
-            reset_state(sender=self.__class__, instance=self)
+        reset_state(sender=self.__class__, instance=self)
 
     def _connect_m2m_relations(self):
-        m2m_handler = set_m2m_dirty if self.RESET_STATE_ON_SAVE_ONLY else reset_state
+        m2m_handler = set_m2m_dirty if self.ENABLE_BASIC_M2M_CHECK else reset_state
         for m2m_field, model in get_m2m_with_model(self.__class__):
             m2m_changed.connect(
                 m2m_handler, sender=remote_field(m2m_field).through, weak=False,
@@ -127,7 +126,7 @@ class DirtyFieldsMixin(object):
         return modified_fields
 
     def is_dirty(self, check_relationship=False, check_m2m=None):
-        if self.RESET_STATE_ON_SAVE_ONLY and self._m2m_dirty:
+        if self.ENABLE_BASIC_M2M_CHECK and self._m2m_dirty:
             return True
         return {} != self.get_dirty_fields(check_relationship=check_relationship,
                                            check_m2m=check_m2m)
@@ -172,7 +171,7 @@ def reset_state(sender, instance, **kwargs):
         instance._original_state = new_state
     if instance.ENABLE_M2M_CHECK:
         instance._original_m2m_state = instance._as_dict_m2m()
-    elif instance.RESET_STATE_ON_SAVE_ONLY:
+    elif instance.ENABLE_BASIC_M2M_CHECK:
         instance._m2m_dirty = False
 
 

--- a/src/dirtyfields/dirtyfields.py
+++ b/src/dirtyfields/dirtyfields.py
@@ -28,7 +28,8 @@ class DirtyFieldsMixin(object):
                 name=self.__class__.__name__))
         if self.ENABLE_M2M_CHECK:
             self._connect_m2m_relations()
-        reset_state(sender=self.__class__, instance=self)
+        if not self.DISABLE_RESET_STATE_ON_M2M_CHANGED:
+            reset_state(sender=self.__class__, instance=self)
 
     def _connect_m2m_relations(self):
         m2m_handler = set_m2m_dirty if self.DISABLE_RESET_STATE_ON_M2M_CHANGED else reset_state

--- a/tests/test_m2m_fields.py
+++ b/tests/test_m2m_fields.py
@@ -54,16 +54,23 @@ def test_m2m_disabled_does_not_allow_to_check_m2m_fields():
 
 
 @pytest.mark.django_db
-def test_dirty_fields_on_m2m_and_assert_num_queries(django_assert_num_queries):
-    with django_assert_num_queries(2):
-        tm = TestM2MModel.objects.create()
-        tm2 = TestModel.objects.create()
-    with django_assert_num_queries(4):
-        tm.m2m_field.add(tm2)
+def test_m2m_mode_disabled_start_dirty_tracking():
+    tm = TestM2MModelWithoutM2MModeEnabled.objects.create()
+    tm2 = TestModel.objects.create()
+    tm.start_dirty_tracking()
 
-    with django_assert_num_queries(1):
-        tm3 = TestM2MModel.objects.get(id=tm.id)
+    tm.m2m_field.add(tm2)
 
-    assert tm3.get_dirty_fields(check_m2m={'m2m_field': set([tm2.id])}) == {}
-    assert tm.get_dirty_fields(check_m2m={'m2m_field': set([0])}) == {'m2m_field': set([tm2.id])}
-    assert tm.get_dirty_fields(check_m2m={'m2m_field': set([0, tm2.id])}) == {'m2m_field': set([tm2.id])}
+    assert tm._as_dict_m2m() == {'m2m_field': set([tm2.id])}
+
+    # m2m check should be explicit: you have to give the values you want to compare with db state.
+    # This first assertion means that m2m_field has one element of id tm2 in the database.
+    assert tm.get_dirty_fields(check_m2m={'m2m_field': set([tm2.id])}) == {}
+
+    # This second assertion means that I'm expecting a m2m_field that is related to an element with id 0
+    # As it differs, we return the previous saved elements.
+    assert tm.get_dirty_fields(check_m2m={'m2m_field': set([0])}) == {
+        'm2m_field': set([tm2.id])}
+
+    assert tm.get_dirty_fields(check_m2m={'m2m_field': set([0, tm2.id])}) == {
+        'm2m_field': set([tm2.id])}

--- a/tests/test_m2m_fields.py
+++ b/tests/test_m2m_fields.py
@@ -5,7 +5,7 @@ from .models import TestModel, TestM2MModel, TestModelWithCustomPK, TestM2MModel
 
 
 @pytest.mark.django_db
-def test_dirty_fields_on_m2m(django_assert_num_queries):
+def test_dirty_fields_on_m2m():
     tm = TestM2MModel.objects.create()
     tm2 = TestModel.objects.create()
     tm.m2m_field.add(tm2)
@@ -51,26 +51,3 @@ def test_m2m_disabled_does_not_allow_to_check_m2m_fields():
 
     with pytest.raises(Exception):
         assert tm.get_dirty_fields(check_m2m={'dummy': True})
-
-
-@pytest.mark.django_db
-def test_m2m_mode_disabled_start_dirty_tracking():
-    tm = TestM2MModelWithoutM2MModeEnabled.objects.create()
-    tm2 = TestModel.objects.create()
-    tm.start_dirty_tracking()
-
-    tm.m2m_field.add(tm2)
-
-    assert tm._as_dict_m2m() == {'m2m_field': set([tm2.id])}
-
-    # m2m check should be explicit: you have to give the values you want to compare with db state.
-    # This first assertion means that m2m_field has one element of id tm2 in the database.
-    assert tm.get_dirty_fields(check_m2m={'m2m_field': set([tm2.id])}) == {}
-
-    # This second assertion means that I'm expecting a m2m_field that is related to an element with id 0
-    # As it differs, we return the previous saved elements.
-    assert tm.get_dirty_fields(check_m2m={'m2m_field': set([0])}) == {
-        'm2m_field': set([tm2.id])}
-
-    assert tm.get_dirty_fields(check_m2m={'m2m_field': set([0, tm2.id])}) == {
-        'm2m_field': set([tm2.id])}


### PR DESCRIPTION
Instead of resetting the state everytime an M2M field is changed, reset it when the object is saved.
Also currently won't give you which m2m fields changed but only that it has changed.